### PR TITLE
feature:#12 Gateway에서 Reissue 진행시 request parameter 누락 해결

### DIFF
--- a/src/main/java/com/t3t/apigateway/filter/GlobalHttpReIssueFilter.java
+++ b/src/main/java/com/t3t/apigateway/filter/GlobalHttpReIssueFilter.java
@@ -17,7 +17,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
-import java.net.URI;
 import java.util.Objects;
 
 /**
@@ -66,7 +65,13 @@ public class GlobalHttpReIssueFilter implements GlobalFilter, Ordered {
                     WebClient webClient = WebClient.create();
                     Mono<ClientResponse> responseMono = webClient.post()
                             // 추후 profile별 url로 전송되게 해야함
-                            .uri("http://localhost:8084/refresh")
+                            .uri(uriBuilder -> uriBuilder
+                                    .scheme("http")
+                                    .host("localhost")
+                                    .port(8084)
+                                    .path("/refresh")
+                                    .query(exchange.getRequest().getURI().getQuery()) // 이전 요청의 쿼리 파라미터 추가
+                                    .build())
                             .header(HttpHeaders.AUTHORIZATION, "Bearer " + access)
                             .exchange();
 
@@ -75,7 +80,7 @@ public class GlobalHttpReIssueFilter implements GlobalFilter, Ordered {
                         String receivedNewToken = resp.headers().asHttpHeaders().getFirst(HttpHeaders.AUTHORIZATION);
 
                         ServerHttpRequest originalReq = finalExchange.getRequest().mutate()
-                                .uri(URI.create(originalUrl))
+                                .uri(finalExchange.getRequest().getURI())
                                 .header(HttpHeaders.AUTHORIZATION, receivedNewToken)
                                 .build();
 
@@ -92,7 +97,13 @@ public class GlobalHttpReIssueFilter implements GlobalFilter, Ordered {
 
                 WebClient webClient = WebClient.create();
                 Mono<ClientResponse> responseMono = webClient.post()
-                        .uri("http://localhost:8084/refresh")
+                        .uri(uriBuilder -> uriBuilder
+                                .scheme("http")
+                                .host("localhost")
+                                .port(8084)
+                                .path("/refresh")
+                                .query(exchange.getRequest().getURI().getQuery()) // 이전 요청의 쿼리 파라미터 추가
+                                .build())
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + access)
                         .exchange();
 
@@ -101,7 +112,7 @@ public class GlobalHttpReIssueFilter implements GlobalFilter, Ordered {
                     String receivedNewToken = resp.headers().asHttpHeaders().getFirst(HttpHeaders.AUTHORIZATION);
 
                     ServerHttpRequest originalReq = finalExchange.getRequest().mutate()
-                            .uri(URI.create(originalUrl))
+                            .uri(finalExchange.getRequest().getURI())
                             .header(HttpHeaders.AUTHORIZATION, receivedNewToken)
                             .build();
 


### PR DESCRIPTION
WebClient에서 Authorization Header만 추가하던것을 Request Parameters도 받게 수정
**** 현재는 재발급이 무조건 localhost:8084로 돌아가게 되어있어서 추후 실제 서버 포트로 수정되게 해야함 ****